### PR TITLE
Add relevant parts of mechanisation of Bailitis' Bachelor's thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ The FOL library currently extends this core with the following content:
 - [Deduction](theories/Deduction): More deduction systems not included in the core library.
 - [Semantics](theories/Semantics): More semantics not included in the core library.
 - [Completeness](theories/Completeness): Completeness results for Tarski, Kripke, and algebraic semantics, constructive where possible.
-- [Incompleteness](theories/Incompleteness): An abstract and synthetic version of the first incompleteness theorem, instantiated to Robinson's Q.
+- [Incompleteness](theories/Incompleteness): An abstract and synthetic version of the first incompleteness theorem, instantiated to Robinson's Q, as well as a proof of the first incompleteness theorem and Tarski's theorem via Carnap's diagonal lemma.
 - [Tennenbaum](theories/Tennenbaum): Tennenbaum's theorem stating that the natural numbers are the only computable model of PA, constructivised.
 - [ArithmeticalHierachy](theories/ArithmeticalHierarchy): Semantic and syntactic characterisations of the arithmetical hierarchy and an equivalence proof.
 - [Proofmode](theories/Proofmode): A tool easing derivations in a deduction system, including a HOAS input language hiding de Bruijn encoded syntax.
 - [Reification](theories/Reification): A tactic automating representability proofs of Coq predicates as first-order formulas.
 - [Utils](theories/Utils): A collection of additional results needed in various projects.
+- [HilbertSystem](theories/HilbertSystem): A Hilbert system for first-order logic with a proof of its equivalence to natural deduction.
 
 ## Installation
 

--- a/theories/HilbertSystem/hilbert_system.v
+++ b/theories/HilbertSystem/hilbert_system.v
@@ -1,0 +1,46 @@
+From Undecidability.FOL Require Import Syntax.Core Arithmetics.Robinson.
+From FOL Require Import ProofMode.
+Require Import List.
+
+Section Hil_def.
+    Context {Σ_funcs : funcs_signature}.
+    Context {Σ_preds : preds_signature}.
+    Existing Instance falsity_on. 
+
+    (** * Hilbert Systems *)
+
+    Implicit Type p : peirce.
+
+    Inductive hilAx: forall (ff: falsity_flag) (p: peirce), form -> Prop :=
+    | HK phi psi {p}: hilAx p (phi → psi → phi)
+    | HS phi psi tau {p}: hilAx p ((phi → psi → tau) → (phi → psi) → phi → tau)
+    | CI phi psi {p}: hilAx p (phi → psi → phi ∧ psi)
+    | CE1 phi psi {p}: hilAx p (phi ∧ psi → phi)
+    | CE2 phi psi {p}: hilAx p (phi ∧ psi → psi)
+    | DI1 phi psi {p}: hilAx p (phi → phi ∨ psi)
+    | DI2 phi psi {p}: hilAx p (psi → phi ∨ psi)
+    | DE phi psi tau {p}: hilAx p (phi ∨ psi → (phi → tau) → (psi → tau) → tau)
+    | Ebot phi {p}: hilAx p (⊥ → phi)
+    | AllE t phi {p}: hilAx p ((∀ phi) → phi[t..])
+    | AllG phi {p}: hilAx p (phi → ∀ phi[↑])
+    | AllD phi psi {p}: hilAx p ((∀ phi → psi) → (∀ phi) → (∀ psi)) 
+    | ExI phi t {p}: hilAx p (phi[t..] → ∃ phi)
+    | ExE phi psi {p}: hilAx p ((∃ phi) → (∀ phi → psi[↑]) → psi)
+    | PC phi psi: hilAx class (((phi → psi) → phi) → phi).
+
+    Inductive hilprv A |: forall (p: peirce), form -> Prop :=
+    | MP phi psi {p}: hilprv p phi -> hilprv p (phi → psi) -> hilprv p psi
+    | HilAx phi n {p}: hilAx p phi -> hilprv p (forall_times n phi)
+    | ThAx phi {p}: In phi A -> hilprv p phi.
+
+    Definition thilprv {p: peirce} (T: form -> Prop) (phi: form):=
+        exists A, (forall phi, In phi A -> T phi) /\ hilprv A p phi.
+
+End Hil_def.
+
+Notation "A ⊢H phi" := (hilprv A _ phi) (at level 55).
+Notation "A ⊢HI phi" := (@hilprv _ _ A intu phi) (at level 55).
+Notation "A ⊢HC phi" := (@hilprv _ _ A class phi) (at level 55).
+Notation "T ⊢HT phi" := (thilprv T phi) (at level 55).
+Notation "T ⊢HTI phi" := (@thilprv _ _ intu T phi) (at level 55).
+Notation "T ⊢HTC phi" := (@thilprv _ _ class T phi) (at level 55).

--- a/theories/HilbertSystem/hilbert_system_deduction_facts.v
+++ b/theories/HilbertSystem/hilbert_system_deduction_facts.v
@@ -1,0 +1,380 @@
+From Equations Require Import Equations.
+From FOL.HilbertSystem Require Import hilbert_system.
+From Undecidability.FOL Require Import Arithmetics.Robinson.
+From FOL Require Import ProofMode.
+Require Import String List.
+
+Section ND_Hil_equiv.
+
+  Context {Σ_funcs : funcs_signature}.
+  Context {Σ_preds : preds_signature}.
+  Context {eq_dec: EqDec form}.
+  Existing Instance falsity_on.
+
+  (** * Equivalence Proof of Hilbert System and ND *)
+  (** ** Preliminary Facts *)
+  Lemma axiom_inclusion {p: peirce} A φ:
+      hilAx p φ -> A ⊢H φ.
+  Proof.
+      intros Hax. eapply (HilAx _ 0 Hax).
+  Qed.
+
+  Lemma operational_K {p: peirce} A φ ψ:
+      A ⊢H φ -> A ⊢H ψ → φ.
+  Proof.
+      intros Hφ. eapply MP; first eassumption.
+      apply axiom_inclusion. constructor.
+  Qed.
+
+  Lemma operational_S {p: peirce} A φ ψ τ:
+      A ⊢H (φ → ψ → τ) -> A ⊢H (φ → ψ) -> A ⊢H (φ → τ).
+  Proof.
+      intros H1 H2. eapply MP.
+      2: { eapply MP; last eapply (axiom_inclusion A (HS _ _ _)). eassumption. }
+      assumption.
+  Qed.
+
+  Lemma identity {p: peirce} A φ:
+      A ⊢H φ → φ.
+  Proof.
+      eapply MP; last eapply MP.
+      3: { eapply (axiom_inclusion A (HS φ (φ → φ) φ)). }
+      1-2: apply (axiom_inclusion A (HK _ _)).
+  Qed.
+
+  Theorem deduction_theorem {p: peirce} A φ ψ: 
+      (φ::A) ⊢H ψ -> A ⊢H φ → ψ.
+  Proof.
+      induction 1 as [φ' ψ' p _ IH1 _ IH2 | φ' n | ψ' p HA].
+          - eapply operational_S; eassumption.
+          - apply operational_K. apply HilAx. assumption.
+          - destruct (eq_dec φ ψ').
+              + rewrite e. eapply identity.
+              + cbn in HA. assert (In ψ' A) by intuition congruence.
+                apply operational_K. apply ThAx. assumption.
+  Qed.
+
+  Section CompatibilityLemmas.
+
+      (** ** Compatibility Lemmas *)
+
+      Context {p: peirce}.
+
+      Lemma compat_IE A φ ψ:
+          A ⊢H φ → ψ -> A ⊢H φ -> A ⊢H ψ.
+      Proof.
+          intros Himpl Hφ. eapply MP; eassumption.
+      Qed.
+
+      Lemma forall_times_once n φ:
+          ∀ (forall_times n φ) = forall_times (S n) φ.
+      Proof.
+          cbn. easy.
+      Qed.
+
+      Lemma compat_AllI A φ:
+          map (subst_form ↑) A ⊢H φ -> A ⊢H ∀ φ.
+      Proof.
+          induction 1 as [φ ψ p _ IH1 _  IH2 | φ n p Hax | φ p HA].
+              - eapply MP; first eapply IH1.
+                eapply MP; first eapply IH2.
+                apply (HilAx _ 0). constructor.
+              - rewrite forall_times_once. apply (HilAx _ _). assumption.
+              - assert (exists τ, (subst_form ↑) τ = φ /\ In τ A) as [τ [<- Hτ]].
+                apply in_map_iff. assumption.
+                eapply MP.
+                2: { eapply (HilAx _ 0). eapply AllG. }
+                apply ThAx. assumption.
+      Qed.
+
+      Lemma compat_AllE A φ t:
+          A ⊢H ∀ φ -> A ⊢H φ[t..].
+      Proof.
+          intros HAll. eapply MP; first eassumption.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_ExI A φ t:
+          A ⊢H φ[t..] -> A ⊢H ∃ φ.
+      Proof.
+          intros Hφ. eapply MP; first eassumption.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_ExE A φ ψ:
+          A ⊢H ∃ φ -> (φ::(map (subst_form ↑) A)) ⊢H ψ[↑] -> A ⊢H ψ.
+      Proof.
+          intros Hex Hψ. apply deduction_theorem in Hψ.
+          apply compat_AllI in Hψ.
+          eapply MP; first eapply Hψ.
+          eapply MP; first eapply Hex.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_Exp A φ:
+          A ⊢H ⊥ -> A ⊢H φ.
+      Proof.
+          intros Hbot. eapply MP; first eassumption.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_ctx A φ:
+          In φ A -> A ⊢H φ.
+      Proof.
+          intros HA. apply ThAx. assumption.
+      Qed.
+
+      Lemma compat_CI A φ ψ:
+          A ⊢H φ -> A ⊢H ψ -> A ⊢H φ ∧ ψ.
+      Proof.
+          intros Hφ Hψ. eapply MP.
+          2: { eapply MP; first eapply Hφ. eapply (HilAx _ 0).
+              econstructor. }
+          assumption.
+      Qed.
+
+      Lemma compat_CE1 A φ ψ:
+          A ⊢H φ ∧ ψ -> A ⊢H φ.
+      Proof.
+          intros Hconj. eapply MP; first eassumption.
+          eapply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_CE2 A φ ψ:
+          A ⊢H φ ∧ ψ -> A ⊢H ψ.
+      Proof.
+          intros Hconj. eapply MP; first eassumption.
+          eapply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_DI1 A φ ψ:
+          A ⊢H φ -> A ⊢H φ ∨ ψ.
+      Proof.
+          intros Hφ. eapply MP; first eassumption.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_DI2 A φ ψ:
+          A ⊢H ψ -> A ⊢H φ ∨ ψ.
+      Proof.
+          intros Hψ. eapply MP; first eassumption.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_DE A φ ψ τ:
+          A ⊢H φ ∨ ψ -> (φ::A) ⊢H τ -> (ψ::A) ⊢H τ -> A ⊢H τ.
+      Proof.
+          intros Hdisj Hφ Hψ. apply deduction_theorem in Hφ, Hψ.
+          eapply MP; first eapply Hψ.
+          eapply MP; first eapply Hφ.
+          eapply MP; first eapply Hdisj.
+          apply (HilAx _ 0). constructor.
+      Qed.
+
+      Lemma compat_Pc A φ ψ:
+          A ⊢HC (((φ → ψ) → φ) → φ).
+      Proof.
+          apply axiom_inclusion. constructor.
+      Qed.
+
+  End CompatibilityLemmas.
+
+
+  Theorem ND_to_Hil: 
+      forall (p : peirce) (A : list form) (φ : form), A ⊢ φ -> A ⊢H φ.
+  Proof.
+      apply (@prv_ind_full _ _ (fun p A φ => A ⊢H φ)); intros p A φ.
+          - intros ψ _ IH. apply deduction_theorem. assumption.
+          - intros ψ _ IH1 _ IH2. eapply compat_IE; eassumption.
+          - intros _ IH. apply compat_AllI. assumption.
+          - intros t _ IH. apply compat_AllE. assumption.
+          - intros t _ IH. eapply compat_ExI. eassumption.
+          - intros ψ _ IH1 _ IH2. eapply compat_ExE; eassumption.
+          - intros _ IH. apply compat_Exp. assumption.
+          - intros HA. apply compat_ctx. assumption.
+          - intros ψ _ IH1 _ IH2. apply compat_CI; assumption.
+          - intros ψ _ IH. eapply compat_CE1. eassumption.
+          - intros ψ _ IH. eapply compat_CE2. eassumption.
+          - intros ψ _ IH. apply compat_DI1. assumption.
+          - intros ψ _ IH. apply compat_DI2. assumption.
+          - intros ψ τ _ IH1 _ IH2 _ IH3. eapply compat_DE; eassumption.
+          - apply compat_Pc.
+  Qed.
+
+  Section SoundnessLemmas.
+
+    (** ** Soundness Lemmas *)
+
+    Context {p: peirce}.
+
+    Lemma sound_HK A φ ψ:
+      A ⊢ φ → ψ → φ.
+    Proof.
+      fstart. fintros "Hφ" "Hψ". fapply "Hφ".
+    Qed.
+
+    Lemma sound_HS A φ ψ τ:
+      A ⊢ (φ → ψ → τ) → (φ → ψ) → φ → τ.
+    Proof.
+      fstart. fintros "f" "g" "Hφ". fapply "f".
+        - fapply "Hφ".
+        - fapply "g". fapply "Hφ".
+    Qed.
+
+    Lemma sound_CI A φ ψ:
+      A ⊢ φ → ψ → φ ∧ ψ.
+    Proof.
+      fstart. fintros "Hφ" "Hψ". fsplit.
+        - fapply "Hφ".
+        - fapply "Hψ".
+    Qed.
+
+    Lemma sound_CE1 A φ ψ:
+      A ⊢ φ ∧ ψ → φ.
+    Proof.
+      fstart. fintros "[Hφ Hψ]". fapply "Hφ".
+    Qed.
+
+    Lemma sound_CE2 A φ ψ:
+      A ⊢ φ ∧ ψ → ψ.
+    Proof.
+      fstart. fintros "[Hφ Hψ]". fapply "Hψ".
+    Qed.
+
+    Lemma sound_DI1 A φ ψ:
+      A ⊢ φ → (φ ∨ ψ).
+    Proof.
+      fstart. fintros "Hφ". fleft. fapply "Hφ".
+    Qed.
+
+    Lemma sound_DI2 A φ ψ:
+      A ⊢ ψ → (φ ∨ ψ).
+    Proof.
+      fstart. fintros "Hψ". fright. fapply "Hψ".
+    Qed.
+
+    Lemma sound_DE A φ ψ τ:
+      A ⊢ φ ∨ ψ → (φ → τ) → (ψ → τ) → τ.
+    Proof.
+      fstart. fintros "[Hφ|Hψ]"; fintros "f" "g".
+        - fapply "f". fapply "Hφ".
+        - fapply "g". fapply "Hψ".
+    Qed.
+
+    Lemma sound_Ebot A φ:
+      A ⊢ ⊥ → φ.
+    Proof.
+      fstart. fintros "H⊥". fexfalso. fapply "H⊥".
+    Qed.
+
+    Lemma sound_AllE A φ t:
+      A ⊢ (∀ φ) → φ[t..].
+    Proof.
+      fstart. fintros "Hφ". fapply "Hφ".
+    Qed.
+
+    Lemma sound_AllG A φ:
+      A ⊢ φ → ∀ φ[↑].
+    Proof.
+      fstart. fintros "Hφ" x. fapply "Hφ".
+    Qed.
+
+    Lemma sound_AllD A φ ψ:
+      A ⊢ (∀ φ → ψ) → (∀ φ) → ∀ ψ.
+    Proof.
+      fstart. fintros "Himpl" "Hφ" x.
+      fspecialize ("Himpl" x). fapply "Himpl".
+      fapply "Hφ".
+    Qed.
+
+    Lemma sound_ExI A φ t:
+      A ⊢ φ[t..] → ∃ φ.
+    Proof.
+      fstart. fintros "Hφ". fexists t. fapply "Hφ".
+    Qed.
+
+    Lemma sound_ExE A φ ψ:
+      A ⊢ (∃ φ) → (∀ φ → ψ[↑]) → ψ.
+    Proof.
+      fstart. fintros "[x Hφ]" "f". fapply ("f" x).
+      fapply "Hφ".
+    Qed.
+
+    Lemma sound_PC A φ ψ:
+      A ⊢C (((φ → ψ) → φ) → φ).
+    Proof.
+      apply Pc.
+    Qed.
+
+    Lemma empty_context_AllI φ:
+      nil ⊢ φ -> nil ⊢ ∀ φ.
+    Proof.
+      intros Hall. apply AllI. cbn. assumption.
+    Qed.
+
+    Corollary empty_context_forall_times_intro φ n:
+      nil ⊢ φ -> nil ⊢ forall_times n φ.
+    Proof.
+      intros Hφ. induction n as [| n IH]; cbn.
+        - assumption.
+        - apply empty_context_AllI. assumption.
+    Qed.
+
+    Lemma quantifed_hilAx_derivable φ n:
+      hilAx p φ -> nil ⊢ forall_times n φ.
+    Proof.
+      intros Hax. apply empty_context_forall_times_intro. inversion Hax.
+        - apply sound_HK.
+        - apply sound_HS.
+        - apply sound_CI.
+        - apply sound_CE1.
+        - apply sound_CE2.
+        - apply sound_DI1.
+        - apply sound_DI2.
+        - apply sound_DE.
+        - apply sound_Ebot.
+        - apply sound_AllE.
+        - apply sound_AllG.
+        - apply sound_AllD.
+        - apply sound_ExI.
+        - apply sound_ExE.
+        - apply sound_PC.
+    Qed.
+
+  End SoundnessLemmas.
+
+  (** ** Equivalence Proof *)
+
+  Theorem Hil_to_ND (p: peirce) φ A:
+    A ⊢H φ -> A ⊢ φ.
+  Proof.
+    induction 1 as [φ ψ p' _ IH1 _ IH2 | φ n Hφ | φ Hincl].
+      - eapply IE; eassumption.
+      - eapply Weak.
+        + eapply quantifed_hilAx_derivable. assumption.
+        + easy.
+      - apply Ctx. assumption.
+  Qed.
+
+  Corollary Hil_ND_agree (p: peirce) φ A:
+    A ⊢H φ <-> A ⊢ φ.
+  Proof.
+      split.
+      - apply Hil_to_ND.
+      - intros Hφ. apply (@ND_to_Hil p _ _); assumption.
+  Qed.
+
+  Corollary Hil_ND_agree_theories (p: peirce) φ T:
+    T ⊢HT φ <-> T ⊢T φ.
+  Proof.
+    split.
+      - intros [A [HA HDer]]. exists A. split; first assumption.
+        apply Hil_ND_agree; assumption.
+      - intros [A [HA Hder]]. exists A. split; first eassumption.
+        destruct (Hil_ND_agree p φ A). easy.
+  Qed.
+
+End ND_Hil_equiv.
+
+
+

--- a/theories/Incompleteness/abstract_loeb.v
+++ b/theories/Incompleteness/abstract_loeb.v
@@ -1,0 +1,125 @@
+From Equations Require Import Equations.
+Require Equations.Type.DepElim.
+From FOL.Proofmode Require Import Theories ProofMode.
+From FOL Require Import FullSyntax Arithmetics.
+
+Require FOL.Proofmode.Hoas.
+Require Import String List.
+
+Import ListNotations.
+Open Scope string_scope.
+
+(** * Löb's Theorem *)
+
+Existing Instance PA_funcs_signature.
+Existing Instance PA_preds_signature.
+Existing Instance full_operators.
+Existing Instance falsity_on.
+
+Instance eqdec_funcs : EqDec PA_funcs_signature.
+Proof. intros x y; decide equality. Qed.
+
+Instance eqdec_preds : EqDec PA_preds_signature.
+Proof. intros x y. destruct x, y. now left. Qed.
+
+Section Löb.
+
+  Variables pei: peirce.
+  Variables T: form -> Prop.
+
+  (** ** Derivability Conditions *)
+
+  Variables box: form -> form.
+  Notation "□ A" := (box A) (at level 5, no associativity).
+
+  Variables necessitation: forall A, T ⊩ A -> T ⊩ □A.
+  Variables internal_necessitation: forall A, T ⊩ (□A → □□A).
+  Variables box_distr: forall A B, T ⊩ (□(A → B) → □A → □B).
+
+  Variables modal_fixpoint: forall P, exists ψ, T ⊩ (ψ ↔ (□ψ → P)).
+
+  (** ** Proof of Löb's Theorem *)
+
+  Lemma Lob's_lemma P:
+    exists ψ, T ⊩ (ψ ↔ (□ψ → P)) /\ T ⊩ (□ψ → □P).
+  Proof.
+    destruct (modal_fixpoint P) as [ψ equiv]. exists ψ. split; first assumption.
+    apply T_CE1 in equiv as H2.
+    apply necessitation in H2.
+    assert (H4: T ⊩ (□ψ → □(□ψ → P))).
+    fstart. now fapply box_distr. 
+    specialize (box_distr (□ψ) P) as H5.
+    assert (H6: T ⊩ (□ψ → □(□ψ) → □P)).
+    fstart. fintros "H1". fapply H5. fapply H4. (* fapply "H1" diverges *)
+    fstop. apply T_Ctx. eapply contains_extend1.
+    fstart. fintros "H". fapply H6.
+    - fstop. apply T_Ctx. eapply contains_extend1.
+    - fapply internal_necessitation. fstop. apply T_Ctx.
+      eapply contains_extend1.
+  Qed. 
+
+  Lemma Lob's_theorem P:
+    (T ⊩ (□P → P)) -> T ⊩ P.
+  Proof.
+    intros HLöb. destruct (Lob's_lemma  P) as [ψ [Hequiv Hlem]].
+    assert (T ⊩ (□ψ → P)) as H10.
+    fstart. fintros "H". fapply HLöb. fapply Hlem.
+    fstop. apply T_Ctx. eapply contains_extend1.
+    apply T_CE2 in Hequiv as H11.
+    assert (T ⊩ ψ) as H12.
+    eapply T_IE; first eassumption. assumption.
+    eapply T_IE; first eassumption. apply necessitation. assumption.
+  Qed.
+
+(** ** Internal Löb's Theorem *)
+
+  Lemma int_Lob's_theorem P:
+    T ⊩ (□(□P → P) → □P).
+  Proof.
+    destruct (modal_fixpoint P) as [ψ equiv]. 
+    assert (T ⊩ (ψ → □ψ → P)) as H1.
+    now eapply T_CE1. 
+    apply necessitation in H1.
+    assert (T ⊩ (□ψ → □((□ ψ) → P))) as H2.
+    now fapply box_distr.
+    assert (T ⊩ (□ψ → □(□ψ) → □P)) as H3.
+    apply T_II. apply switch_imp_T in H2. 
+    now fapply box_distr.
+    assert (T ⊩ (□ψ → □P)) as H4.
+    fstart. fintros "H". 
+    fapply H3; last fapply internal_necessitation.
+    1-2: fstop; apply T_Ctx; apply contains_extend1.
+    assert (T ⊩ ((□P → P) → (□ψ → P))) as H5.
+    fstart. fintros "Hf" "Hψ". fapply "Hf". fapply H4.
+    fstop. apply T_Ctx. apply contains_extend1.
+    assert (T ⊩ ((□P → P) → ψ)) as H6.
+    apply T_CE2 in equiv.
+    fstart. fintros "H". fapply equiv. fapply H5.
+    fstop. apply T_Ctx. apply contains_extend1.
+    assert (T ⊩ (□(□P → P) → □ψ)) as H7.
+    fapply box_distr. now apply necessitation.
+    fstart. fintros "H". fapply H4. fapply H7.
+    fstop. apply T_Ctx. apply contains_extend1.
+  Qed.
+
+  Corollary Lob's_theorem_from_int P:
+    T ⊩ (□P → P) -> T ⊩ P.
+  Proof.
+    intros HLöb. assert (T ⊩ □(□P → P)) as Hint.
+    now apply necessitation.
+    enough (T ⊩ □P) as HBox.
+    now fapply HLöb.
+    now fapply int_Lob's_theorem.
+  Qed.
+
+(** ** Gödel's Second Incompleteness Theorem *)
+
+  Corollary Godel's_second_incompleteness_theorem:
+    ~T ⊢T ⊥ -> ~T ⊢T ¬□ ⊥.
+  Proof.
+    intros Hconsistent [A [Hincl HprovCons]].
+    apply Hconsistent. apply Lob's_theorem. 
+    exists A. split; assumption.
+  Qed.
+      
+End Löb.

--- a/theories/Incompleteness/diagonal_lemma.v
+++ b/theories/Incompleteness/diagonal_lemma.v
@@ -1,0 +1,191 @@
+From Undecidability.Shared Require Import Dec.
+From Undecidability.Synthetic Require Import Definitions EnumerabilityFacts DecidabilityFacts SemiDecidabilityFacts.
+
+From Equations Require Import Equations.
+Require Equations.Type.DepElim.
+
+From FOL Require Import FullSyntax Arithmetics.
+
+(** Gödelisation of formulas *)
+Class goedelisation {ops: operators} {ff: falsity_flag} {fns: funcs_signature} {prs: preds_signature}:=
+     {g: form -> nat; f: nat -> form; inv_fg: forall x, x = f (g x)}. (** If we define this underneath the imports, strange errors occur. *)
+
+From FOL.Proofmode Require Import Theories ProofMode DemoPA.
+
+From FOL.Incompleteness Require Import Axiomatisations utils fol_utils qdec bin_qdec sigma1 epf epf_mu ctq formula_deduction_utils.
+
+Require FOL.Proofmode.Hoas.
+Require Import String Lia List.
+
+Import ListNotations.
+Open Scope string_scope.
+
+(** * Diagonal Lemma *)
+
+Existing Instance PA_funcs_signature.
+Existing Instance PA_preds_signature.
+Existing Instance full_operators.
+Existing Instance falsity_on.
+
+Section Diagonal_Lemma.
+    
+    Variables pei: peirce.
+
+    (** The numeral of a formula's Gödel number *)
+    Definition quine_quote {göd: goedelisation} φ := num (g φ).
+
+    Lemma qq_closed {göd: goedelisation} A:
+      bounded_t 0 (quine_quote A).
+    Proof.
+      unfold quine_quote. apply num_bound.
+    Qed.
+
+    Variables göd: goedelisation.
+
+    Implicit Types (A B: form).
+    (** ** Preliminary Definitions *)
+    (* We define what the diagonalisation of a given formula is. *)
+
+    Definition diagonalisation A := A[(quine_quote A)..].
+
+    Definition diag_nat n := g (diagonalisation (f n)).
+
+    (** Satity check. Diagonalisation on formulas and Gödel numbers coincide *)
+    Lemma diag_göd_comm A:
+      diag_nat (g A) = g (diagonalisation A).
+    Proof.
+      unfold diag_nat. rewrite <- inv_fg. reflexivity.
+    Qed.
+
+    Lemma subst_bound_2_with_term_subst (ψ: form) (n: nat) (y: term) (sigma: nat -> term) (rho: nat -> term):
+        bounded 2 ψ -> ψ[(num n) .: y..] = ψ[(num n)`[rho] .: y .: sigma].
+    Proof.
+        rewrite num_subst. apply subst_bound_2.
+    Qed.
+
+    (** diag_nat is captured by a Σ1-formula φd due to CTQ *)
+
+    Variables φ_D: form.
+    Variables φ_D_bound: bounded 2 φ_D.
+    Variables φ_D_is_Σ1: Σ1 φ_D.
+    Variables φ_D_Hcapt: forall x, Qeq ⊢ ∀ φ_D[num x .: $0..] ↔ $0 == num (diag_nat x).
+
+    (** The formulas F and G as in the thesis, needed to prove the diagonal lemma *)
+    Definition diag_F A := ∃ φ_D[$1 .: $0..] ∧ A[$0..].
+    Definition diag_G A := diagonalisation (diag_F A).    
+
+    Lemma qq_representation A:
+      Qeq ⊢ ∀ φ_D[quine_quote A .: $0..] ↔ $0 == num (g (diagonalisation A)).
+    Proof.
+      rewrite <- diag_göd_comm. unfold quine_quote. apply φ_D_Hcapt.
+    Qed. 
+
+    Lemma diag_G_closed A:
+      bounded 1 A -> bounded 0 (diag_G A).
+    Proof.
+      intros HA. unfold diag_G. unfold diagonalisation.
+      unfold diag_F. asimpl. unfold quine_quote.
+      rewrite <- subst_bound_2_with_term_subst; last assumption.
+      constructor. constructor.
+        - eapply subst_bounded_max; last eassumption.
+          intros k Hk. destruct k; first apply num_bound.
+          destruct k; first (constructor; lia). lia.
+        - rewrite <- subst_bound_1; last assumption.
+        replace (A[_]) with A.
+        2: { pose (fun n => var n) as sigma. symmetry.
+             assert (A[$0..] = A[sigma]) as ->.
+             eapply bounded_subst; first eassumption.
+             intros k Hk. destruct k; easy.
+             apply subst_id. easy. }
+        assumption.
+    Qed.
+
+    (** ** Proof of the Diagonal Lemma *)
+    Theorem diagonal_lemma B:
+       bounded 1 B -> exists G: form, bounded 0 G /\ Qeq ⊢ G ↔ B[(quine_quote G)..].
+    Proof.
+    intros HB. exists (diag_G B). split; first apply (diag_G_closed HB). fstart.    
+    fsplit.
+     - unfold diag_G. unfold diagonalisation. unfold diag_F. cbn. fintros "[x [Hφ HBdiag]]".
+       replace (φ_D[_][_][_]) with (φ_D[quine_quote (diag_F B) .: x..]).
+       2: { asimpl. apply subst_bound_2. assumption. }
+       replace (B[_][_][_]) with (B[x..]).
+       2: { asimpl. apply subst_bound_1. assumption. } 
+       replace (B[(quine_quote (_))..]) with (B[(quine_quote (diag_G B))..]).
+       2: { asimpl. apply subst_bound_1. assumption. }
+
+       specialize (qq_representation (diag_F B)) as HDF. fspecialize (HDF x).
+       asimpl in HDF.
+       replace (φ_D[_]) with (φ_D[(quine_quote (diag_F B)) .: x..]) in HDF.
+       2: { apply subst_bound_2_with_term_subst. assumption. }
+       replace (num (_)) with ((num (g (diag_G B)))) in HDF.
+       2: { unfold diag_G. unfold diag_F. unfold diagonalisation. asimpl. easy. }
+       rewrite num_subst in HDF.
+       fdestruct HDF as "[HreprL HreprR]".
+       feapply Q_leibniz. 2: fapply "HBdiag".
+       unfold quine_quote. fapply "HreprL". fapply "Hφ".
+       - fintros "HBdiag". 
+         specialize (qq_representation (diag_F B)) as HDF.
+         fspecialize (HDF (quine_quote (diag_G B))). rewrite num_subst in HDF. 
+         replace (φ_D[_][_]) with (φ_D[(quine_quote (diag_F B)) .: (quine_quote (diag_G B))..]) in HDF.
+         2: { asimpl. apply subst_bound_2_with_term_subst. assumption. }
+         replace (∃ _) with (diag_G B) in HDF; last easy.
+         fdestruct HDF as "[HreprL HreprR]". fexists (quine_quote (diag_G B)). 
+         replace (φ_D[_][_][_]) with (φ_D[(quine_quote (diag_F B)) .: (quine_quote (diag_G B))..]).
+         2: { asimpl. apply subst_bound_2. assumption. }
+         replace (B[_][_][_]) with (B[(quine_quote (diag_G B))..]).
+         2: { asimpl. apply subst_bound_1. assumption. }
+         fsplit.
+          + fapply "HreprR". (* Why are definitions unfolded here? *)
+            unfold quine_quote. fapply ax_refl. 
+          + fapply "HBdiag".
+    Qed.
+
+
+End Diagonal_Lemma.
+
+(** Wrapper to access the diagonal lemma directly. Used as interface for other theories relying onthe diagonal lemma *)
+Lemma CTQ_gives_Diagonal_Lemma {pei: peirce} {göd: goedelisation}:
+    CTQ -> forall B, bounded 1 B -> exists G, bounded 0 G /\ Qeq ⊢ G ↔ B[(quine_quote G)..].
+Proof.
+    intros HCTQ. apply ctq_ctq_total in HCTQ. 
+    destruct (HCTQ (diag_nat göd)) as (φ_D & Hφ_D_Bound & Hφ_D_Σ1 & Hφ_D_repr).
+    eapply diagonal_lemma; eassumption.
+Qed.
+
+(** Carnap's diagonalisation equivalence *)
+Lemma diagonalisation_equivalence {göd: goedelisation}:
+    @CTQ intu -> forall B, bounded 1 B -> exists G, bounded 0 G /\ interp_nat ⊨= (G ↔ B[(quine_quote G)..]).
+Proof.
+    intros HCTQ H HB. specialize (CTQ_gives_Diagonal_Lemma HCTQ HB) as [G [HGBnd HGequiv]].
+    apply soundness in HGequiv. exists G. split; first assumption.
+    intros ρ. specialize (HGequiv nat interp_nat ρ). apply HGequiv.
+    intros φ Hφ. now apply nat_is_Q_model.
+Qed.
+
+(** ** Counterexamples from Generalised Diagonal Lemma *)
+Lemma Diagonal_Lemma_mult_counterexample {pei: peirce} {göd: goedelisation}:
+    ~exists G, Qeq ⊢ G ↔ quine_quote G == quine_quote G /\ Qeq ⊢ G ↔ quine_quote  G== σ (quine_quote G).
+Proof.
+    intros [G [HG1 HG2]]. 
+    assert (Qeq ⊢ num (g G) == σ (num (g G))) as Heq.
+    fapply HG2. fapply HG1. fapply ax_refl.
+    eapply Σ1_soundness in Heq.
+    Unshelve. 4: exact (fun _ => 0).
+    2: { constructor. apply Qdec_eq. }
+    2: { solve_bounds; apply num_bound. }
+    cbn in Heq. now repeat rewrite nat_eval_num in Heq.
+Qed.
+
+Local Ltac close HG HB := rewrite num_subst in HG; now rewrite (bounded_0_subst _ HB) in HG.
+
+Lemma Diagonal_Lemma_bound_counterexample {pei: peirce} {göd: goedelisation}:
+    ~exists G, bounded 0 G /\ Qeq ⊢ G ↔ quine_quote G == $0.
+Proof.
+    unfold quine_quote.
+    intros [G [HB HG]]. apply Qeq_generalisation in HG.
+    apply Diagonal_Lemma_mult_counterexample.
+    exists G; split.
+    - fspecialize (HG (num (g G))). close HG HB.
+    - fspecialize (HG (σ (num (g G)))). close HG HB.
+Qed.

--- a/theories/Incompleteness/external_provability.v
+++ b/theories/Incompleteness/external_provability.v
@@ -1,0 +1,146 @@
+From Equations Require Import Equations.
+From Undecidability.Shared Require Import Dec.
+From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts MoreReducibilityFacts.
+
+From FOL Require Import FullSyntax Arithmetics.
+From FOL.Proofmode Require Import Theories ProofMode.
+
+From FOL.Incompleteness Require Import Axiomatisations utils fol_utils qdec bin_qdec sigma1 epf epf_mu ctq diagonal_lemma formula_deduction_utils.
+
+Require FOL.Proofmode.Hoas.
+Require Import String Lia List.
+(** * External Provability Predicates *)
+
+Section Ext_prov.
+
+Existing Instance PA_funcs_signature.
+Existing Instance PA_preds_signature.
+Existing Instance full_operators.
+Existing Instance falsity_on.
+
+
+Variables pei: peirce.
+Variables ctq: CTQ.
+
+Variables göd: goedelisation.
+
+(** ** Σ1-soundness *)
+
+Definition Sig1_sound T := forall φ, T ⊢TC φ -> bounded 0 φ -> Σ1 φ -> interp_nat ⊨= φ.
+
+Lemma Sig1_sound_consistent T {p: peirce}:
+    Sig1_sound T -> ~T ⊩ ⊥.
+Proof.
+    intros HSound Hbot. enough (interp_nat ⊨= ⊥) as HSatis.
+    { cbn in HSatis. apply HSatis. exact (fun n => 0). }
+    apply peirce_to_class_theory in Hbot. apply HSound; first easy.
+    - now solve_bounds.
+    - constructor. apply Qdec_bot.
+Qed.
+
+(** Enumerable predicates in Σ1-sound extensions T of Q are weakly representable in T *)
+Lemma Sig1_sound_weak_representability T P:
+    (forall φ, In φ Qeq -> T φ) -> enumerable P -> 
+    Sig1_sound T -> exists φ,
+    bounded 1 φ /\ Σ1 φ /\ forall n, P n <-> T ⊢T φ[(num n)..]. 
+Proof.
+    intros Hincl Henum Hsound.
+    destruct (ctq_weak_repr (ctq_ctq_total ctq) Henum) as (φ & Hbnd & HΣ1 & Hrepr).
+    exists φ. repeat split; try easy.
+    - intros Hn. eapply WeakT.
+      + apply (list_theory_provability Qeq). now apply Hrepr.
+      + eauto.
+    - intros Hφ. apply Hrepr. assert (Σ1 φ[(num n)..]) as HsubΣ1.
+      now apply Σ1_subst. assert (bounded 0 φ[(num n)..]) as Hclosed.
+      eapply subst_bounded_max. 2: eassumption. intros i Hi.
+      destruct i; first apply num_bound. lia.
+      apply Σ1_completeness; try assumption.
+      apply peirce_to_class_theory in Hφ.
+      now apply Hsound.
+Qed.
+
+(** ** Definitions  *)
+Definition ext_prov_pred T prov_T := bounded 1 prov_T /\ forall φ, T ⊢T φ -> T ⊢T prov_T[(quine_quote φ)..].
+Definition sound_prov_pred T prov_T := ext_prov_pred T prov_T /\ forall φ, T ⊢T prov_T[(quine_quote φ)..] -> T ⊢T φ.
+
+(** ** Enumerability Facts *)
+Lemma prv_enum_red T X (h: X -> form):
+    enumerable__T X -> enumerable T -> enumerable (fun x => T ⊢T h x).
+Proof.
+    intros HX HT. assert (enumerable (fun φ => T ⊢T φ)) as HT'.
+    apply (@tprv_enumerable PA_funcs_signature PA_preds_signature enumerable_PA_funcs _ enumerable_PA_preds _ T HT pei).
+    assert ((fun x => T ⊢T h x) ⪯ (fun φ => T ⊢T φ)) as Hred.
+    now exists h.
+    eapply enumerable_red; try eassumption.
+    apply discrete_iff. constructor. apply dec_form.
+    - apply PA_funcs_eq.
+    - apply PA_preds_eq.
+    - apply dec_full_logic_sym.
+    - apply dec_full_logic_quant.
+Qed.
+
+Corollary num_tprv_enum T:
+    enumerable T -> enumerable (fun n => T ⊢T f n).
+Proof.
+    apply prv_enum_red. eapply enumerator_enumerable.
+    apply enumerator__T_nat.
+Qed.
+
+Corollary num_tprv_neg_enum T:
+    enumerable T -> enumerable (fun n => T ⊢T ¬f n).
+Proof.
+    apply prv_enum_red. eapply enumerator_enumerable.
+    apply enumerator__T_nat.
+Qed.
+
+(** ** Construction of External Provability Predicates *)
+
+Lemma ex_prov_T_util T:
+    enumerable T -> Sig1_sound T -> (forall φ, In φ Qeq -> T φ) ->
+      exists prov_T, bounded 1 prov_T /\ Σ1 prov_T /\ (forall n, T ⊢T f n <-> T ⊢T prov_T[(num n)..]).
+Proof.
+    intros Henum Hsound Hincl. apply num_tprv_enum in Henum.
+    destruct (Sig1_sound_weak_representability Hincl Henum Hsound) as (prov_T & Hbnd & HΣ1 & Hrepr).
+    exists prov_T. repeat split; firstorder.
+Qed.
+
+(** A sound external provability predicate *)
+Lemma ex_prov_T T:
+    enumerable T -> Sig1_sound T -> (forall φ, In φ Qeq -> T φ) ->
+      exists prov_T, Σ1 prov_T /\ sound_prov_pred T prov_T.
+Proof.
+    intros Henum Hsound Hincl.
+    destruct (ex_prov_T_util Henum Hsound Hincl) as (prov_T & Hbnd & HΣ1 & Hrepr).
+    exists prov_T. unfold sound_prov_pred. unfold ext_prov_pred.
+    repeat split; try assumption; intros φ Hφ.
+    - apply Hrepr. now rewrite <- inv_fg.
+    - rewrite inv_fg. now apply Hrepr.
+Qed.
+
+(** An external provability predicate sProv(x) such that also T ⊢ ¬φ -> T ⊢ ¬sProv[(quine_quote φ)..] is satisfied *)
+Lemma ex_sProv_T T:
+    enumerable T -> ~T ⊢T ⊥ -> (forall φ, In φ Qeq -> T φ) ->
+      exists sProv_T, Σ1 sProv_T /\ ext_prov_pred T sProv_T /\
+      forall φ, T ⊢T ¬φ -> T ⊢T ¬sProv_T[(quine_quote φ)..].
+Proof.
+    intros HT Hcons Hincl.
+    assert (enumerable (fun n => T ⊢T f n)) as HT'.
+    now apply num_tprv_enum.
+    apply num_tprv_neg_enum in HT.
+    apply enumerable_semi_decidable in HT; last apply discrete_nat.
+    apply enumerable_semi_decidable in HT'; last apply discrete_nat.
+    assert (forall n, T ⊢T f n -> T ⊢T ¬f n -> False) as Hdisj.
+    intros n H1 H2. apply Hcons. eapply T_IE; first eassumption. easy.
+    destruct (ctq_strong_sepr ctq Hdisj HT' HT) as (sProv_T & HsProvB & HsProvΣ & HsProvReprL & HsProvReprR). 
+    unfold ext_prov_pred. exists sProv_T. repeat split; try assumption; intros φ Hφ.
+    - eapply WeakT.
+      + apply (list_theory_provability Qeq). apply HsProvReprL. 
+        now rewrite <- inv_fg.
+      + eauto.
+    - eapply WeakT. 
+      + apply (list_theory_provability Qeq). apply HsProvReprR. 
+        now rewrite <- inv_fg.
+      + eauto.
+Qed.
+
+End Ext_prov.

--- a/theories/Incompleteness/formula_deduction_utils.v
+++ b/theories/Incompleteness/formula_deduction_utils.v
@@ -76,48 +76,11 @@ Proof.
     destruct k; first easy. lia.
 Qed.
 
-Inductive aand (P Q R : Prop) :=
-      cconj : P -> Q -> R -> aand P Q R.
-
-Lemma form_inv {Σ_funcs : funcs_signature} {Σ_preds : preds_signature} {ops : operators} {flag : falsity_flag} phi1 phi2 :
-      phi1 = phi2 ->
-      match phi1, phi2 with
-      | falsity, falsity => True
-      | atom _ P1 args1, atom _ P2 args2 => True
-      | bin falsity_on o1 phi1' phi2', bin falsity_on o2 phi1'' phi2'' =>
-            aand (o1 = o2) (phi1' = phi1'') (phi2' = phi2'')
-      | bin falsity_off o1 phi1' phi2', bin falsity_off o2 phi1'' phi2'' =>
-          aand (o1 = o2) (phi1' = phi1'') (phi2' = phi2'')
-      | quant falsity_on o1 phi, quant falsity_on o2 phi' =>
-            o1 = o2 /\ phi = phi'
-      | quant falsity_off o1 phi, quant falsity_off o2 phi' =>
-          o1 = o2 /\ phi = phi'
-      | _, _ => False
-      end.
-Proof.
-      intros H. destruct phi1; subst; eauto.
-      all: destruct b; econstructor; eauto.
-Qed.
-
 Section Formula_facts.
 
     Existing Instance PA_funcs_signature.
     Existing Instance PA_preds_signature.
     Existing Instance full_operators.
-
-    Definition impl_dec {ff: falsity_flag}:
-        forall (φ ψ: form), {τ & ψ = τ → φ} + ({τ & ψ = τ → φ} -> False).
-    Proof.
-        intros φ ψ. destruct ψ as [| ff P ts | ff b τ χ | ff q τ].
-            * right. intros [τ Hτ]. congruence.
-            * right. intros [τ Hτ]. congruence.
-            * destruct b. 1-2: right; intros [τ' Hτ']; congruence.
-              destruct (dec_form _ _ _ _  χ φ).
-                + left. exists τ. congruence.
-                + right. intros [τ' Hτ']. apply n.
-                  destruct ff; eapply form_inv in Hτ' as []; congruence.
-            * right. intros [τ' Hτ']. congruence.
-    Qed.
 
     Lemma list_theory_provability {p: peirce} {ff: falsity_flag} A φ:
     A ⊢ φ <-> list_theory A ⊢T φ.

--- a/theories/Incompleteness/formula_deduction_utils.v
+++ b/theories/Incompleteness/formula_deduction_utils.v
@@ -1,0 +1,131 @@
+From FOL Require Import FullSyntax Arithmetics ProofMode.
+From FOL.Incompleteness Require Import Axiomatisations sigma1 qdec utils.
+From Undecidability.FOL.Utils Require Import FriedmanTranslation.
+Require Import Lia.
+(** * Utilities *)
+(** ** Translation between Classical and Intuitionistic Reasoning *)
+Section Translations.
+
+    Existing Instance PA_funcs_signature.
+    Existing Instance PA_preds_signature.
+    Existing Instance full_operators.
+    Existing Instance falsity_on.
+
+    Lemma Σ1_convervativity' {pei: peirce} (ϕ: form):
+        Σ1 ϕ -> bounded 0 ϕ -> Qeq ⊢C ϕ -> Qeq ⊢ ϕ.
+    Proof.
+        intros HΣ1 HB Hclass. destruct pei; first assumption.
+        apply Σ1_conservativity; assumption.
+    Qed.
+
+    Lemma peirce_to_class {pei: peirce} (ϕ: form) T:
+        T ⊢ ϕ -> T ⊢C ϕ.
+    Proof.
+        destruct pei; first easy. apply prv_intu_peirce.
+    Qed.
+
+    Lemma peirce_to_class_theory {pei: peirce} (ϕ: form) T:
+        T ⊢T ϕ -> T ⊢TC ϕ.
+    Proof.
+        intros [L HL]. exists L. split; first easy.
+        now apply peirce_to_class.
+    Qed.
+
+End Translations.
+(** ** Utilities on Robinson Arithmetic *)
+Section Robinson_facts.
+    
+    Existing Instance PA_funcs_signature.
+    Existing Instance PA_preds_signature.
+    Existing Instance full_operators.
+    Existing Instance falsity_on.
+
+    Lemma Qeq_consistent {p: peirce}:
+        ~Qeq ⊢ ⊥.
+    Proof.
+        intros HderBot. enough (FalseSat: interp_nat ⊨= ⊥).
+        - cbn in FalseSat. apply FalseSat. easy.
+        - apply Σ1_soundness. 2-3: try constructor; auto.
+          constructor. apply Qdec_bot.
+    Qed.
+
+    Lemma Qeq_generalisation {p: peirce} φ:
+        Qeq ⊢ φ -> Qeq ⊢ ∀ φ.
+    Proof.
+        intros Hφ. apply AllI. 
+        now assert (List.map (subst_form ↑) Qeq = Qeq) as -> by easy.
+    Qed.
+
+End Robinson_facts.
+
+(** ** Utilities for Formulas *)
+Lemma subst_bound_1 {Σ_funcs : funcs_signature} {Σ_preds : preds_signature} {ops : operators} {flag : falsity_flag} 
+    (ψ: form) (x: term) (sigma: nat -> term):
+    bounded 1 ψ -> ψ[x..] = ψ[x .: sigma].
+Proof.
+    intro HBound. eapply bounded_subst; first eassumption.
+    intros k Hk. destruct k; first easy. lia.
+Qed.
+      
+Lemma subst_bound_2 {Σ_funcs : funcs_signature} {Σ_preds : preds_signature} {ops : operators} {flag : falsity_flag} 
+    (ψ: form) (x y: term) (sigma: nat -> term):
+    bounded 2 ψ -> ψ[x .: y..] = ψ[x .: y .: sigma].
+Proof.
+    intro HBound. eapply bounded_subst; first eassumption.
+    intros k Hk. destruct k; first easy.
+    destruct k; first easy. lia.
+Qed.
+
+Inductive aand (P Q R : Prop) :=
+      cconj : P -> Q -> R -> aand P Q R.
+
+Lemma form_inv {Σ_funcs : funcs_signature} {Σ_preds : preds_signature} {ops : operators} {flag : falsity_flag} phi1 phi2 :
+      phi1 = phi2 ->
+      match phi1, phi2 with
+      | falsity, falsity => True
+      | atom _ P1 args1, atom _ P2 args2 => True
+      | bin falsity_on o1 phi1' phi2', bin falsity_on o2 phi1'' phi2'' =>
+            aand (o1 = o2) (phi1' = phi1'') (phi2' = phi2'')
+      | bin falsity_off o1 phi1' phi2', bin falsity_off o2 phi1'' phi2'' =>
+          aand (o1 = o2) (phi1' = phi1'') (phi2' = phi2'')
+      | quant falsity_on o1 phi, quant falsity_on o2 phi' =>
+            o1 = o2 /\ phi = phi'
+      | quant falsity_off o1 phi, quant falsity_off o2 phi' =>
+          o1 = o2 /\ phi = phi'
+      | _, _ => False
+      end.
+Proof.
+      intros H. destruct phi1; subst; eauto.
+      all: destruct b; econstructor; eauto.
+Qed.
+
+Section Formula_facts.
+
+    Existing Instance PA_funcs_signature.
+    Existing Instance PA_preds_signature.
+    Existing Instance full_operators.
+
+    Definition impl_dec {ff: falsity_flag}:
+        forall (φ ψ: form), {τ & ψ = τ → φ} + ({τ & ψ = τ → φ} -> False).
+    Proof.
+        intros φ ψ. destruct ψ as [| ff P ts | ff b τ χ | ff q τ].
+            * right. intros [τ Hτ]. congruence.
+            * right. intros [τ Hτ]. congruence.
+            * destruct b. 1-2: right; intros [τ' Hτ']; congruence.
+              destruct (dec_form _ _ _ _  χ φ).
+                + left. exists τ. congruence.
+                + right. intros [τ' Hτ']. apply n.
+                  destruct ff; eapply form_inv in Hτ' as []; congruence.
+            * right. intros [τ' Hτ']. congruence.
+    Qed.
+
+    Lemma list_theory_provability {p: peirce} {ff: falsity_flag} A φ:
+    A ⊢ φ <-> list_theory A ⊢T φ.
+    Proof.
+        split; intros H.
+        - exists A. eauto.
+        - destruct H as [B [HBIncl HBderiv]]. eapply Weak; first eassumption.
+        eauto.
+    Qed.
+    
+End Formula_facts.

--- a/theories/Incompleteness/limitative_theorems.v
+++ b/theories/Incompleteness/limitative_theorems.v
@@ -1,0 +1,272 @@
+From Undecidability.Shared Require Import Dec.
+From Undecidability.Synthetic Require Import Definitions EnumerabilityFacts DecidabilityFacts SemiDecidabilityFacts ReducibilityFacts.
+
+From Equations Require Import Equations.
+Require Equations.Type.DepElim.
+
+From FOL Require Import FullSyntax Arithmetics.
+From FOL.Proofmode Require Import Theories ProofMode DemoPA.
+
+From FOL.Incompleteness Require Import Axiomatisations utils fol_utils qdec bin_qdec sigma1 epf epf_mu ctq formal_systems fol_incompleteness formula_deduction_utils diagonal_lemma external_provability.
+
+Require FOL.Proofmode.Hoas.
+Require Import String Lia List.
+
+Import ListNotations.
+Open Scope string_scope. 
+
+Existing Instance PA_funcs_signature.
+Existing Instance PA_preds_signature.
+Existing Instance full_operators.
+Existing Instance falsity_on.
+
+(** * Limitative Theorems *)
+(** ** Indefinability *)
+Section Indefinability.
+
+    Variables pei: peirce.
+    Variables ctq: CTQ.
+    Variables göd: goedelisation.
+
+    (* First, we "enable" classical reasoning when proving stable claims (is explicit form really needed?)*)
+    Definition stable (P: Prop) := ~~P -> P.
+
+    Lemma stable_classical (P Q: Prop):
+      stable Q -> (P \/ ~P -> Q) -> Q.
+    Proof.
+      unfold stable. tauto.
+    Qed.
+
+    (** Definability *)
+    Definition defines_pred (φ: form) (P: form -> Prop) (T: form -> Prop) := bounded 1 φ /\ 
+      (forall ψ, (P ψ -> T ⊢T φ[(quine_quote ψ)..])) /\ (forall ψ, ~P ψ -> T ⊢T ¬φ[(quine_quote ψ)..]).
+
+    Definition definable (P: form -> Prop) (T: form -> Prop) := exists φ, defines_pred φ P T.
+
+    (** The indefinability theorem: (fun φ => T ⊢T φ) is not definable if T is a consistent extension of Q *)
+    Lemma thm_god_not_definable (T: form -> Prop):
+     (forall φ, In φ Qeq -> T φ) -> ~ T ⊢T ⊥ ->  ~ definable (fun φ => T ⊢T φ) T. 
+    Proof.
+      intros Hincl Hconsistent [φ [HBound [HdefL HdefR]]].
+      assert (HBound': bounded 1 (¬ φ)). constructor; first assumption. constructor.
+      destruct (CTQ_gives_Diagonal_Lemma ctq HBound') as [G [HGBnd HG]].
+      eapply stable_classical. Unshelve. 3: exact (T ⊢T G).
+        - unfold stable. tauto.
+        - intros [HgG | HgG]; apply Hconsistent.
+          + specialize (HdefL G).
+            destruct (HdefL HgG) as [B [HBincl HBderiv]].
+            destruct HgG as [A [HAincl HAderiv]].
+            assert (HderivWk: (A ++ B ++ Qeq) ⊢ G). eapply Weak; first eassumption. auto with *. (* Is this good style? *)
+            exists (app A (app B Qeq)). split.
+              * intros ψ Hψ. destruct (in_app_or _ _ _ Hψ); auto. destruct (in_app_or _ _ _ H); auto.
+              * fstart. (* The following is a workaround since fdestruct HG as "[L R]" diverges. *)
+                assert (HGWk: (A ++ B ++ Qeq) ⊢ G ↔ (¬ φ)[(quine_quote G)..]). eapply Weak; first eassumption. auto with *. 
+                assert (HBderivWk: (A ++ B ++ Qeq) ⊢ φ[(quine_quote G)..]). eapply Weak; first eassumption. auto with *.
+                fdestruct HGWk as "[L R]". fapply "L"; first fapply HderivWk. fapply HBderivWk. 
+          + exfalso. apply HgG. specialize (HdefR G).
+            destruct (HdefR HgG) as [A [HAincl HAderiv]]. exists (app A Qeq). split.
+              * intros ψ Hψ. destruct (in_app_or _ _ _ Hψ); auto. 
+              * assert (HGWk: (A ++ Qeq) ⊢ G ↔ (¬ φ)[(quine_quote G)..]); eapply Weak; auto with *.
+                assert (HAderivWk: (A ++ Qeq) ⊢ ¬ φ[(quine_quote G)..]); eapply Weak; auto with *.
+                fstart. fdestruct HGWk as "[L R]". fapply "R". fapply HAderivWk.
+    Qed.    
+     
+    (* This definition is not taken from the literature, just an auxilliary tool. *)
+    (* It is definability of P where the backwards directions are also true. *)
+    (** Definability, where, in addition, both backwards directions are true *)
+    Definition defines_pred_strongly (φ: form) (P: form -> Prop) (T: form -> Prop) := bounded 1 φ /\ 
+      (forall ψ, (P ψ <-> T ⊢T φ[(quine_quote ψ)..])) /\ (forall ψ, ~P ψ <-> T ⊢T ¬φ[(quine_quote ψ)..]).
+
+    Definition strongly_definable (P: form -> Prop) (T: form -> Prop) := exists φ, defines_pred_strongly φ P T.
+
+    (** In particular, the indefinability theorem implies that (fun φ => T ⊢T φ) is not strongly definable *)
+    Corollary god_not_strongly_definable (T: form -> Prop):
+      (forall φ, In φ Qeq -> T φ) -> ~ T ⊢T ⊥ ->  ~ strongly_definable (fun φ => T ⊢T φ) T. 
+    Proof.
+      intros Hincl Hconsistent [φ [HBound [HdefL HdefR]]].
+      apply (thm_god_not_definable Hincl Hconsistent).
+      exists φ. repeat split; first assumption.
+        - intros ψ Hψ. now apply -> HdefL.
+        - intros ψ Hψrefut. now apply HdefR.
+    Qed.
+
+    (** Every decidable predicate is strongly definable *)
+    Lemma decidable_pred_is_definable (P: form -> Prop) (T: form -> Prop):
+      (forall φ, In φ Qeq -> T φ) -> ~T ⊢T ⊥ -> decidable P -> strongly_definable P T.
+    Proof.
+      intros HIncl Hconsistent HP.
+      pose (fun n => P (f n)) as Q.
+      assert (decidable Q) as HQ. eapply dec_red. 2: eapply HP. now exists f.
+      pose (fun n => ~Q n) as R.
+      assert (decidable R) as HR. apply dec_compl. assumption.
+      assert (semi_decidable Q /\ semi_decidable R) as [HQs HRs]. auto using decidable_semi_decidable.
+      destruct HQ as [fQ HfQ]. destruct HR as [fR HfR].
+      assert (Hdisj: forall n, Q n -> R n -> False).
+      unfold R. tauto. destruct (ctq_strong_sepr ctq Hdisj HQs HRs) as (τ & HτBound & HτΣ1 & HτQ & HτR).
+      exists τ. repeat split.
+        - assumption.
+        - intros HPn. exists Qeq. split; first auto.
+          apply HτQ. unfold Q. now rewrite <- inv_fg.
+        - intros Hτn. destruct (fR (g ψ)) eqn:E.
+          + apply (HfR (g ψ)) in E. specialize (HτR _ E). exfalso. apply Hconsistent.
+            eapply T_IE; last eapply Hτn. exists Qeq. split; first auto. easy.
+          + destruct (HfQ (g ψ)) as [HfQL HfQR]. destruct (fQ (g ψ)) eqn:E'; first now rewrite inv_fg.
+            exfalso. assert (~R (g ψ)). destruct (HfR (g ψ)) as [HfRL _]. rewrite E in HfRL.
+            auto. assert (~Q (g ψ)) by auto. contradiction.
+        - intros HPψ. exists Qeq. split; first auto. apply HτR. unfold R.
+          unfold Q. now rewrite <- inv_fg.
+        - intros Hτ pn. apply Hconsistent. specialize (HτQ (g ψ)).
+          eapply T_IE; first eapply Hτ. exists Qeq. split; first auto.
+          apply HτQ. unfold Q. now rewrite <- inv_fg.
+    Qed.
+
+    (** Essential undecidability: In consistent extensions of Q, provability is not decidable *)
+    Corollary essential_undecidability (T: form -> Prop):
+      (forall φ, In φ Qeq -> T φ) -> ~T ⊢T ⊥ -> ~ decidable (fun φ => T ⊢T φ).
+    Proof.
+      intros HIncl Hconsistent [dec_T Hdec_T].
+      apply (god_not_strongly_definable HIncl Hconsistent). 
+      apply decidable_pred_is_definable. 1-2: assumption.
+      exists (fun φ => dec_T φ). intro φ. auto.
+    Qed.
+
+End Indefinability.
+
+(** ** Tarski's Theorem *)
+Section Tarski.
+
+    Variables ctq: @CTQ intu.
+    Variables göd: goedelisation.
+
+    (** Tarski's Theorem: There is no formula true_N(x) such that interp_nat ⊨= φ iff interp_nat ⊨= true_N[(quine_quote φ)..] for all sentences φ *)
+    Theorem Tarski's_Theorem:
+      ~exists true_N, bounded 1 true_N /\ forall φ, bounded 0 φ -> interp_nat ⊨= φ <-> interp_nat ⊨= true_N[(quine_quote φ)..].
+    Proof.
+      intros (true_N & HBnd & HRepr).
+      assert (bounded 1 (¬ true_N)) as HBnd'. now solve_bounds.
+      destruct (CTQ_gives_Diagonal_Lemma ctq HBnd') as [G [HGBnd HG]].
+      apply soundness in HG. specialize (HG nat interp_nat (fun n => 0)).
+      specialize (HG (nat_is_Q_model (fun _ : nat => 0))).
+      cbn in HG. destruct HG as [HGL  HGR]. 
+      specialize (HRepr _ HGBnd).
+      eapply stable_classical; first firstorder. Unshelve. 2: exact (interp_nat; (fun _ : nat => 0) ⊨ G).
+      intros [L | R].
+      - apply HGL; first assumption. destruct (HRepr) as [HRepr' _].
+        enough (interp_nat ⊨= true_N[(quine_quote G)..]) as H.
+        { apply H. }
+        apply HRepr. intros ρ. now eapply (sat_closed _ _ _ HGBnd).
+      - apply R. apply HGR. intros HTrue.
+        assert (interp_nat ⊨= true_N[(quine_quote G)..]) as HTrue'.
+        intros ρ. eapply sat_closed. 2: eapply HTrue.
+        eapply subst_bounded_max. 2: eassumption.
+        { intros [| i] Hi; last lia. now apply qq_closed. }
+        apply R. now apply HRepr.
+    Qed.
+      
+End Tarski.
+ (** TODO get Tarski's Theorem via Loeb's reasoning *)
+
+(** ** Gödel's First Incompleteness Theorem *)
+Section Gödel.
+
+    Variables pei: peirce.
+    Variables ctq: CTQ.
+    Variables göd: goedelisation.
+
+    (** From the indefinability theorem, we obtain that enumerable, Σ1-sound extesions of Q are incomplete *)
+    Corollary godel_first_incompleteness_tarski T:
+      enumerable T -> (forall φ, In φ Qeq -> T φ) -> Sig1_sound T -> ~(forall φ, bounded 0 φ -> T ⊩ φ \/ T ⊩ ¬φ).
+    Proof.
+      intros HEnum HIncl HSound Hcomplete.
+      eapply (thm_god_not_definable ctq); first eassumption.
+      - now apply Sig1_sound_consistent.
+      - destruct (ex_prov_T_util ctq göd HEnum HSound HIncl) as (prov & HprovB & HΣ1 & Hrepr).
+        exists prov. repeat split; first assumption.
+        + intros ψ Hψ. apply Hrepr. now rewrite <- inv_fg.
+        + intros ψ Hψ. assert (bounded 0 prov[(quine_quote ψ)..]) as HprovB'.
+          eapply subst_bounded_max. 2: eassumption.
+          { intros [| i] Hi; first apply num_bound. lia. }
+          destruct (Hcomplete prov[(quine_quote ψ)..]) as [HL | HR]; first assumption.
+          * exfalso. apply Hψ. rewrite inv_fg. firstorder.
+          * easy.
+    Qed. 
+    
+    (* Enable ProofMode for theories. *)
+    Instance eqdec_funcs : EqDec PA_funcs_signature.
+    Proof. intros x y; decide equality. Qed.
+
+    Instance eqdec_preds : EqDec PA_preds_signature.
+    Proof. intros x y. destruct x, y. now left. Qed.
+
+    Lemma double_neg_elim_class T φ:
+      T ⊩C (¬¬φ) -> T ⊩C φ.
+    Proof.
+      intros HDN. fcontradict. fapply HDN. 
+      apply T_Ctx. eapply contains_extend1.
+    Qed.
+
+    Lemma contrapositive_elim {p: peirce} T φ ψ:
+      T ⊩ (φ ↔ ψ) -> T ⊩ (¬φ) -> T ⊩ (¬ψ).
+    Proof.
+      intros H1 H2. fstart. fintros "H".
+      fapply H2. fapply H1. fapply "H".
+    Qed.
+
+    (** By diagonalising against the negation of a sound external provability predicate,
+     we find independent sentences for enumerable, Σ1-sound extensions of Q *)
+    Corollary godel_first_incompleteness_Sig1_sound (T: form -> Prop):
+      enumerable T -> (forall φ, In φ Qeq -> T φ) -> Sig1_sound T -> exists G, bounded 0 G /\ ~T ⊩ G /\ ~T ⊩ ¬G.
+    Proof.
+      intros HEnum HIncl HSound.
+      destruct (ex_prov_T ctq göd HEnum HSound HIncl) as (prov & HΣ1 & Hrepr1 & Hrepr2).
+      unfold ext_prov_pred in Hrepr1. destruct Hrepr1 as (HprovB & Hrepr1).
+      assert (HsProvB': bounded 1 (¬prov)). now solve_bounds.
+      destruct (CTQ_gives_Diagonal_Lemma ctq HsProvB') as (G & HGB & HGE).
+      apply list_theory_provability in HGE. eapply (@Weak_T _ _ _ _ _ T _) in HGE.
+      2: { intros φ Hφ. unfold Theories.contains in *.
+           eauto. }
+      cbn in HGE.
+      exists G. repeat split; first assumption.
+      - intros HG. apply (Sig1_sound_consistent HSound). apply T_CE1 in HGE.
+        fstart. fapply HGE; first easy. now apply Hrepr1.
+      - enough (~ T ⊩C ¬G) as HGclass.
+        { intros HG. apply HGclass. now apply peirce_to_class_theory. }
+        intros HG. assert (T ⊩C prov[(num (g G))..]) as Hprov.
+        apply double_neg_elim_class. apply peirce_to_class_theory in HGE.
+        now eapply contrapositive_elim.
+        assert (Σ1 prov[(num (g G))..]) as HΣ1'. now apply Σ1_subst.
+        assert (bounded 0 prov[(num (g G))..]) as HprovB'. 
+        eapply subst_bounded_max. 2: eassumption. 
+        { intros [| i] Hi; first apply num_bound. lia. }
+        assert (Sig1_sound T) as HSound' by easy.
+        specialize (HSound _ Hprov HprovB' HΣ1').
+        apply (Σ1_completeness HΣ1' HprovB') in HSound.
+        apply list_theory_provability in HSound.
+        eapply WeakT in HSound; last eassumption.
+        apply Hrepr2 in HSound. apply peirce_to_class_theory in HSound.
+        apply (@Sig1_sound_consistent _ class HSound').
+        fstart. fapply HG. fapply HSound.
+    Qed.
+
+    (** By diagonalising against ¬sProv(x) from External_Provability.v, 
+    there are independent sentences for all enumerable and consistent extensions of Q *)
+    Corollary godel_first_incompleteness_strong_sep (T: form -> Prop):
+      enumerable T -> (forall φ, In φ Qeq -> T φ) -> ~T ⊩ ⊥ -> exists G, bounded 0 G /\ ~T ⊩ G /\ ~T ⊩ ¬G.
+    Proof.
+      intros HEnum HIncl HConsistent.
+      destruct (ex_sProv_T ctq göd HEnum HConsistent HIncl) as (sProv & HsProvΣ & HsProvReprL & HsProvReprR).
+      destruct HsProvReprL as [HsProvB HsProvReprL].
+      assert (HsProvB': bounded 1 (¬sProv)). now solve_bounds.
+      destruct (CTQ_gives_Diagonal_Lemma ctq HsProvB') as (G & HGB & HGE).
+      apply list_theory_provability in HGE. eapply (@Weak_T _ _ _ _ _ T _) in HGE.
+      2: { intros φ Hφ. unfold Theories.contains in *.
+           eauto. }
+      assert (HGE': T ⊩ (G ↔ ¬sProv[(num (g G))..])) by trivial.
+      exists G. repeat split; first assumption.
+      - intros HG. apply HConsistent. fstart.
+        apply T_CE1 in HGE'. fapply HGE'; first easy. now apply HsProvReprL.
+      - intros HG. apply HConsistent. fstart. fapply HG.
+        apply T_CE2 in HGE'. fapply HGE'. now apply HsProvReprR.
+    Qed.
+
+End Gödel.

--- a/theories/Incompleteness/limitative_theorems.v
+++ b/theories/Incompleteness/limitative_theorems.v
@@ -28,7 +28,7 @@ Section Indefinability.
     Variables ctq: CTQ.
     Variables göd: goedelisation.
 
-    (* First, we "enable" classical reasoning when proving stable claims (is explicit form really needed?)*)
+    (* We can use classical reasoning when proving stable claims *)
     Definition stable (P: Prop) := ~~P -> P.
 
     Lemma stable_classical (P Q: Prop):
@@ -164,7 +164,6 @@ Section Tarski.
     Qed.
       
 End Tarski.
- (** TODO get Tarski's Theorem via Loeb's reasoning *)
 
 (** ** Gödel's First Incompleteness Theorem *)
 Section Gödel.

--- a/theories/Incompleteness/multivariate_ctq.v
+++ b/theories/Incompleteness/multivariate_ctq.v
@@ -139,7 +139,7 @@ Section n_ary_ctq.
             2: { repeat rewrite <- n_ary_subst_update. 
                  symmetry. now apply n_ary_subst_plus_zero_var. }
             fdestruct HReprψ as "[L' R']".
-            unfold g. cbn. specialize embed_eval_interchange as H. cbn in H. rewrite <- H. fsplit.
+            unfold g. specialize embed_eval_interchange as H. cbn in H. rewrite <- H. fsplit.
             * fintros "H". fapply "L'". fapply "R". fapply "H".
             * fintros "H". fapply "L". fapply "R'". fapply "H".
     Qed.

--- a/theories/Incompleteness/multivariate_ctq.v
+++ b/theories/Incompleteness/multivariate_ctq.v
@@ -1,0 +1,196 @@
+From Undecidability.Shared Require Import Dec.
+From Undecidability.Synthetic Require Import Definitions EnumerabilityFacts DecidabilityFacts SemiDecidabilityFacts.
+
+From Equations Require Import Equations.
+Require Equations.Type.DepElim.
+
+From FOL Require Import FullSyntax Arithmetics.
+From FOL.Proofmode Require Import Theories ProofMode DemoPA.
+
+From FOL.Incompleteness Require Import Axiomatisations utils fol_utils qdec bin_qdec sigma1 epf epf_mu ctq formula_deduction_utils.
+
+Require FOL.Proofmode.Hoas.
+Require Import String Lia List Vector.
+Import Vector.VectorNotations Vectors.VectorDef.
+
+Import ListNotations.
+Open Scope string_scope.
+
+(** * Multivariate CT_Q *)
+
+Section n_ary_ctq.
+
+    Existing Instance PA_funcs_signature.
+    Existing Instance PA_preds_signature.
+    Existing Instance full_operators.
+    Existing Instance falsity_on.
+
+    Variables pei: peirce.
+    Variables ctq: CTQ.
+
+    (** * Lemmas for Vectors *)
+    Lemma zero_vector_is_nil {X: Type} (v: Vector.t X 0):
+    [] = v.
+    Proof.
+        apply case0. easy.
+    Qed. 
+
+    Lemma un_vector_inv {X: Type} n (v: Vector.t X (S n)):
+    exists x v', v = x::v'.
+    Proof.
+        specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
+        apply Ht. eauto.
+    Qed.
+
+    Lemma bin_vector_inv {X: Type} n (v: Vector.t X (S (S n))):
+    exists x y v', v = x::y::v'.
+    Proof.
+        assert (exists x v0, v = x::v0) as (x0 & v_one & Hx0).
+        specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
+        apply Ht. eauto.
+        assert (exists x v0, v_one = x::v0) as (x1 & v_nil & Hx1).
+        specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
+        apply Ht. eauto.
+        exists x0, x1, v_nil. congruence.
+    Qed.
+
+    Lemma vector_inv_two_elems {X: Type} (v: Vector.t X 2):
+    exists x y, v = x::y::[].
+    Proof.
+        destruct (@bin_vector_inv _ _ v) as (x & y & v' & H).
+        exists x, y. rewrite <- (zero_vector_is_nil v') in H.
+        congruence.
+    Qed.
+
+    (** ** Premilinary Definitions *)
+
+    (** Produces the function type nat -> nat -> ... -> nat
+        of functions taking (S n) many nats as argument *)
+    Fixpoint n_plus_one_ary_function n := match n with
+    | 0 => nat -> nat
+    | S n => nat -> (n_plus_one_ary_function n)
+    end.
+
+    (** Given f: n_plus_one_ary_function (S n)), yields λ m. f (π1 m) (π2 m) *)
+    Definition arg_embed n (f: n_plus_one_ary_function (S n)):=
+        nat_rec (fun n => n_plus_one_ary_function (S n) -> n_plus_one_ary_function n)
+        (fun f m => f (fst (unembed' m)) (snd (unembed' m)))
+        (fun _ _ f m => f (fst (unembed' m)) (snd (unembed' m))) n f.
+
+    (** Given f and a vector [x1; x2; ...; xn], computes f x1 x2 ... xn *)
+    Definition vector_eval (n: nat) (f: n_plus_one_ary_function n) (nums: t nat (S n)) := 
+        nat_rec (fun m : nat => n_plus_one_ary_function m -> t nat (S m) -> nat)
+        (fun f nums => f (hd nums))
+        (fun n IH f nums => IH (f (hd nums)) (tl nums)) n f nums.
+
+    Lemma embed_eval_interchange n x y nums (f: n_plus_one_ary_function (S n)):
+        vector_eval f (x::y::nums) = vector_eval (arg_embed f) (embed' (x, y) :: nums).
+    Proof.
+        Opaque embed'. Opaque unembed'. 
+        destruct n as [|n].
+        - assert (nums = []) as ->. symmetry. now apply zero_vector_is_nil.
+          cbn. now rewrite unembed'_embed'.
+        - cbn. now rewrite unembed'_embed'. 
+    Qed.
+
+    (** Given [x1; x2; ...; xn], yields the substitution ((num x1) .: (num x2) .: ... .: (num xn) ..)*)
+    Definition n_ary_subst n (nums: t nat (n)) := 
+        fold_right (fun n ρ => (num n) .: ρ) nums (var).
+
+    (** ** Substitution Lemmas *)
+
+    Lemma n_ary_subst_update n ψ (x: nat) (nums: t nat n):
+        ψ[n_ary_subst (x::nums)] = ψ[(num x)..][n_ary_subst nums].
+    Proof.
+        cbn. assert (fold_right (fun (n0 : nat) (ρ : nat -> term) => num n0 .: ρ) nums var = n_ary_subst nums) as -> by easy.
+        asimpl. now repeat rewrite num_subst.
+    Qed.
+
+    Lemma n_ary_subst_update' n ψ (x y: nat) (nums: t nat n):
+        ψ[n_ary_subst (x::y::nums)] = ψ[(num x) .: (num y)..][n_ary_subst nums].
+    Proof.
+        cbn. assert (fold_right (fun (n0 : nat) (ρ : nat -> term) => num n0 .: ρ) nums var = n_ary_subst nums) as -> by easy.
+        asimpl. now repeat rewrite num_subst.
+    Qed.
+
+    Lemma n_ary_subst_plus_zero_var n φ (nums: t nat n):
+        bounded (S n) φ -> φ[n_ary_subst nums][$0..] = φ[n_ary_subst nums].
+    Proof.
+        revert φ. induction n as [| n IH]; intros φ HBound.
+        - assert ([] = nums) as <-. apply zero_vector_is_nil.
+          cbn. asimpl. rewrite <- (subst_var φ) at 2.
+          eapply bounded_subst; first eassumption. intros k Hk.
+          destruct k; easy.
+        - destruct (@un_vector_inv _ _ nums) as (x & nums' & ->). 
+          rewrite n_ary_subst_update. apply IH.
+          eapply subst_bounded_max. 2: eassumption. intros i Hi.
+          destruct i; first apply num_bound. constructor. lia.
+    Qed.
+          
+
+    Lemma subst_deriv_preservance φ k:
+        forall (v: t nat k), Qeq ⊢ φ -> Qeq ⊢ φ[n_ary_subst v].
+    Proof.
+        induction k as [|k IH] in φ |-*.
+        - intros v Hφ. rewrite <- (zero_vector_is_nil v). cbn.
+          now rewrite (subst_var).
+        - intros v Hφ. destruct (@un_vector_inv _ _ v) as (x & v' & ->).
+          rewrite (n_ary_subst_update φ).
+          assert (Qeq ⊢ φ[(num x)..]) as Hφ'.
+          apply Qeq_generalisation in Hφ. fapply Hφ.
+          easy.
+    Qed.
+
+    (** ** Proof of Multivariate CT_Q *)
+
+    Lemma ctq_n_ary:
+        forall n (f: n_plus_one_ary_function n), exists ψ, Σ1 ψ /\ bounded (S (S n)) ψ
+            /\ forall (v: t nat (S n)), Qeq ⊢ ∀ ψ[n_ary_subst v] ↔ $0 == num (vector_eval f v). 
+    Proof.
+        induction n as [|n IH]; intros f.
+        - destruct ((ctq_ctq_total ctq) f) as (ψ & HBoundψ & HΣ1ψ & HReprψ).
+          exists ψ. repeat split; try assumption. intros v.
+          destruct (@un_vector_inv _ _ v) as (n & v_nil & ->).
+          assert ([] = v_nil) as <-. apply zero_vector_is_nil. cbn.
+          replace (ψ[_]) with (ψ[(num n) .: $0..]); first easy.
+          eapply bounded_subst; first eassumption. intros k Hk.
+          destruct k; first easy. destruct k; first easy. lia.
+        - Opaque n_ary_subst. pose (g:= arg_embed f). fold n_plus_one_ary_function in g.
+          destruct (IH g) as [ψ [HΣ1ψ [HBoundψ HReprψ]]].
+          destruct (compress_free HBoundψ) as [ρ [HBoundρ HCompress]].
+          pose (τ := ψ[ρ]). fold τ in HCompress. exists τ. repeat split.
+          + unfold τ. now apply Σ1_subst.
+          + assumption.
+          + intros nums. apply Qeq_generalisation.
+            destruct (@bin_vector_inv _ _ nums) as (x & y & v & Hv).
+            specialize (HReprψ ((embed' (x, y))::v)).
+            rewrite n_ary_subst_update in HReprψ. cbn in HReprψ.
+            specialize (HCompress x y). apply (subst_deriv_preservance v) in HCompress.
+            cbn in HCompress. rewrite Hv. rewrite n_ary_subst_update'. fstart.
+            fdestruct HCompress as "[L R]". fspecialize (HReprψ $0).
+            rewrite num_subst in HReprψ. 
+            replace (ψ[_][_][_]) with (ψ[(num (embed' (x, y)))..][n_ary_subst v]) in HReprψ.
+            2: { repeat rewrite <- n_ary_subst_update. 
+                 symmetry. now apply n_ary_subst_plus_zero_var. }
+            fdestruct HReprψ as "[L' R']".
+            unfold g. rewrite <- embed_eval_interchange. fsplit.
+            * fintros "H". fapply "L'". fapply "R". fapply "H".
+            * fintros "H". fapply "L". fapply "R'". fapply "H".
+    Qed.
+
+    Transparent n_ary_subst.
+
+    (** ** Binary CT_Q *)
+
+    Corollary binary_ctq (f: nat -> nat -> nat):
+        exists ψ, Σ1 ψ /\ bounded 3 ψ 
+            /\ forall n m, Qeq ⊢ ∀ ψ[num n .: (num m)..] ↔ $0 == num (f n m).
+    Proof.
+        specialize (@ctq_n_ary 1) as Hctq. cbn in Hctq.
+        destruct (Hctq f) as (ψ & HΣ1ψ & HBoundψ & HReprψ).
+        exists ψ. repeat split; try assumption.
+        intros n m. now specialize (HReprψ (n::m::[])).
+    Qed. 
+ 
+
+End n_ary_ctq.

--- a/theories/Incompleteness/multivariate_ctq.v
+++ b/theories/Incompleteness/multivariate_ctq.v
@@ -28,40 +28,6 @@ Section n_ary_ctq.
     Variables pei: peirce.
     Variables ctq: CTQ.
 
-    (** * Lemmas for Vectors *)
-    Lemma zero_vector_is_nil {X: Type} (v: Vector.t X 0):
-    [] = v.
-    Proof.
-        apply case0. easy.
-    Qed. 
-
-    Lemma un_vector_inv {X: Type} n (v: Vector.t X (S n)):
-    exists x v', v = x::v'.
-    Proof.
-        specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
-        apply Ht. eauto.
-    Qed.
-
-    Lemma bin_vector_inv {X: Type} n (v: Vector.t X (S (S n))):
-    exists x y v', v = x::y::v'.
-    Proof.
-        assert (exists x v0, v = x::v0) as (x0 & v_one & Hx0).
-        specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
-        apply Ht. eauto.
-        assert (exists x v0, v_one = x::v0) as (x1 & v_nil & Hx1).
-        specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
-        apply Ht. eauto.
-        exists x0, x1, v_nil. congruence.
-    Qed.
-
-    Lemma vector_inv_two_elems {X: Type} (v: Vector.t X 2):
-    exists x y, v = x::y::[].
-    Proof.
-        destruct (@bin_vector_inv _ _ v) as (x & y & v' & H).
-        exists x, y. rewrite <- (zero_vector_is_nil v') in H.
-        congruence.
-    Qed.
-
     (** ** Premilinary Definitions *)
 
     (** Produces the function type nat -> nat -> ... -> nat
@@ -86,11 +52,10 @@ Section n_ary_ctq.
     Lemma embed_eval_interchange n x y nums (f: n_plus_one_ary_function (S n)):
         vector_eval f (x::y::nums) = vector_eval (arg_embed f) (embed' (x, y) :: nums).
     Proof.
-        Opaque embed'. Opaque unembed'. 
         destruct n as [|n].
-        - assert (nums = []) as ->. symmetry. now apply zero_vector_is_nil.
-          cbn. now rewrite unembed'_embed'.
-        - cbn. now rewrite unembed'_embed'. 
+        - assert (nums = []) as ->. now apply vec_0_nil.
+          cbn -[embed' unembed']. now rewrite unembed'_embed'.
+        - cbn -[embed' unembed']. now rewrite unembed'_embed'. 
     Qed.
 
     (** Given [x1; x2; ...; xn], yields the substitution ((num x1) .: (num x2) .: ... .: (num xn) ..)*)
@@ -117,7 +82,7 @@ Section n_ary_ctq.
         bounded (S n) φ -> φ[n_ary_subst nums][$0..] = φ[n_ary_subst nums].
     Proof.
         revert φ. induction n as [| n IH]; intros φ HBound.
-        - assert ([] = nums) as <-. apply zero_vector_is_nil.
+        - assert (nums = []) as ->. apply vec_0_nil.
           cbn. asimpl. rewrite <- (subst_var φ) at 2.
           eapply bounded_subst; first eassumption. intros k Hk.
           destruct k; easy.
@@ -132,7 +97,7 @@ Section n_ary_ctq.
         forall (v: t nat k), Qeq ⊢ φ -> Qeq ⊢ φ[n_ary_subst v].
     Proof.
         induction k as [|k IH] in φ |-*.
-        - intros v Hφ. rewrite <- (zero_vector_is_nil v). cbn.
+        - intros v Hφ. rewrite (vec_0_nil v). cbn.
           now rewrite (subst_var).
         - intros v Hφ. destruct (@un_vector_inv _ _ v) as (x & v' & ->).
           rewrite (n_ary_subst_update φ).
@@ -151,11 +116,11 @@ Section n_ary_ctq.
         - destruct ((ctq_ctq_total ctq) f) as (ψ & HBoundψ & HΣ1ψ & HReprψ).
           exists ψ. repeat split; try assumption. intros v.
           destruct (@un_vector_inv _ _ v) as (n & v_nil & ->).
-          assert ([] = v_nil) as <-. apply zero_vector_is_nil. cbn.
+          assert (v_nil = []) as ->. apply vec_0_nil. cbn.
           replace (ψ[_]) with (ψ[(num n) .: $0..]); first easy.
           eapply bounded_subst; first eassumption. intros k Hk.
           destruct k; first easy. destruct k; first easy. lia.
-        - Opaque n_ary_subst. pose (g:= arg_embed f). fold n_plus_one_ary_function in g.
+        - pose (g:= arg_embed f). fold n_plus_one_ary_function in g.
           destruct (IH g) as [ψ [HΣ1ψ [HBoundψ HReprψ]]].
           destruct (compress_free HBoundψ) as [ρ [HBoundρ HCompress]].
           pose (τ := ψ[ρ]). fold τ in HCompress. exists τ. repeat split.
@@ -164,21 +129,20 @@ Section n_ary_ctq.
           + intros nums. apply Qeq_generalisation.
             destruct (@bin_vector_inv _ _ nums) as (x & y & v & Hv).
             specialize (HReprψ ((embed' (x, y))::v)).
-            rewrite n_ary_subst_update in HReprψ. cbn in HReprψ.
+            rewrite n_ary_subst_update in HReprψ.
             specialize (HCompress x y). apply (subst_deriv_preservance v) in HCompress.
-            cbn in HCompress. rewrite Hv. rewrite n_ary_subst_update'. fstart.
+            cbn -[embed' unembed'] in HCompress. 
+            rewrite Hv. rewrite n_ary_subst_update'. fstart.
             fdestruct HCompress as "[L R]". fspecialize (HReprψ $0).
             rewrite num_subst in HReprψ. 
             replace (ψ[_][_][_]) with (ψ[(num (embed' (x, y)))..][n_ary_subst v]) in HReprψ.
             2: { repeat rewrite <- n_ary_subst_update. 
                  symmetry. now apply n_ary_subst_plus_zero_var. }
             fdestruct HReprψ as "[L' R']".
-            unfold g. rewrite <- embed_eval_interchange. fsplit.
+            unfold g. cbn. specialize embed_eval_interchange as H. cbn in H. rewrite <- H. fsplit.
             * fintros "H". fapply "L'". fapply "R". fapply "H".
             * fintros "H". fapply "L". fapply "R'". fapply "H".
     Qed.
-
-    Transparent n_ary_subst.
 
     (** ** Binary CT_Q *)
 

--- a/theories/Incompleteness/utils.v
+++ b/theories/Incompleteness/utils.v
@@ -37,7 +37,24 @@ Proof.
   inversion 1; now inversion H2.
 Qed.
 
+Lemma un_vector_inv {X: Type} n (v: Vector.t X (S n)):
+    exists x v', v = x::v'.
+Proof.
+    specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
+    apply Ht. eauto.
+Qed.
 
+Lemma bin_vector_inv {X: Type} n (v: Vector.t X (S (S n))):
+    exists x y v', v = x::y::v'.
+Proof.
+    assert (exists x v0, v = x::v0) as (x0 & v_one & Hx0).
+    specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
+    apply Ht. eauto.
+    assert (exists x v0, v_one = x::v0) as (x1 & v_nil & Hx1).
+    specialize (caseS (fun n vn => exists x v', vn = Vector.cons X x n (v'))) as Ht.
+    apply Ht. eauto.
+    exists x0, x1, v_nil. congruence.
+Qed.
 
 (* * Synthetic computability *)
 (* Partial functions **)

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -71,7 +71,15 @@ Incompleteness/bin_qdec.v
 Incompleteness/weak_strong.v
 Incompleteness/ctq.v
 Incompleteness/fol_incompleteness.v
+Incompleteness/formula_deduction_utils.v
+Incompleteness/diagonal_lemma.v
+Incompleteness/external_provability.v
+Incompleteness/limitative_theorems.v
+Incompleteness/abstract_loeb.v
+Incompleteness/multivariate_ctq.v
 
+HilbertSystem/hilbert_system.v
+HilbertSystem/hilbert_system_deduction_facts.v
 
 Tennenbaum/SyntheticInType.v
 Tennenbaum/NumberUtils.v


### PR DESCRIPTION
As part of this pull request, the Rocq development of Janis Bailitis' Bachelor's thesis at the programming systems lab shall be contributed to the Rocq Library of First-Order Logic. This contribution consists of two parts: Firstly, A mechanisation of Hilbert systems for FO alongside equivalence proof to ND (in `theories/HilbertSystem`). Secondly, a mechanisation of Gödel's first incompleteness theorem and Tarski's theorem via Carnap's diagonal lemma (added to previous development in `theories/Incompleteness`). This part of the mechanisation also contains a generalisation of $\mathsf{CT}_\mathsf{Q}$ (see `theories/Incompleteness/ctq.v`) to functions taking multiple arguments, contained in the file  `theories/Incompleteness/multivariate_ctq.v`.

It may be the case that the files do not match guidelines with respect to code formatting. If so, please point this out.